### PR TITLE
Add deprecation warnings for moved fields

### DIFF
--- a/pydantic_forms/validators/components/contact_person_list.py
+++ b/pydantic_forms/validators/components/contact_person_list.py
@@ -36,5 +36,9 @@ def contact_person_list(
     return Annotated[
         conlist(ContactPerson, min_length=min_items, max_length=max_items),
         BeforeValidator(remove_empty_items),
-        Field(json_schema_extra=dict(json_schema_extra())),
+        Field(
+            json_schema_extra=dict(json_schema_extra()),
+            deprecated=True,
+            description="organisationId and organisationKey attributes will be removed, for version with organisations use `from orchestrator.forms.validators import organisation_contact_list` instead of this",
+        ),
     ]  # type: ignore

--- a/pydantic_forms/validators/components/display_subscription.py
+++ b/pydantic_forms/validators/components/display_subscription.py
@@ -16,5 +16,11 @@ from uuid import UUID
 from pydantic import Field
 
 DisplaySubscription = Annotated[
-    UUID, Field(frozen=True, json_schema_extra={"format": "subscription", "type": "string"})
+    UUID,
+    Field(
+        frozen=True,
+        json_schema_extra={"format": "subscription", "type": "string"},
+        deprecated=True,
+        description="Use `from orchestrator.forms.validators import DisplaySubscription` instead of this",
+    ),
 ]

--- a/pydantic_forms/validators/components/organisation_id.py
+++ b/pydantic_forms/validators/components/organisation_id.py
@@ -14,4 +14,11 @@ from typing import Annotated
 
 from pydantic import Field
 
-OrganisationId = Annotated[str, Field(json_schema_extra={"format": "organisationId"})]
+OrganisationId = Annotated[
+    str,
+    Field(
+        json_schema_extra={"format": "organisationId"},
+        deprecated=True,
+        description="Use `from orchestrator.forms.validators import CustomerId` instead of this",
+    ),
+]

--- a/tests/unit_tests/test_contact_person_list.py
+++ b/tests/unit_tests/test_contact_person_list.py
@@ -56,6 +56,7 @@ def test_contact_persons_schema():
                 "organisationKey": "organisation",
                 "title": "Contact Persons",
                 "type": "array",
+                "description": "organisationId and organisationKey attributes will be removed, for version with organisations use `from orchestrator.forms.validators import organisation_contact_list` instead of this",
             },
             "contact_persons_org": {
                 "items": {"$ref": "#/$defs/ContactPerson"},
@@ -64,6 +65,7 @@ def test_contact_persons_schema():
                 "title": "Contact Persons Org",
                 "type": "array",
                 "minItems": 1,
+                "description": "organisationId and organisationKey attributes will be removed, for version with organisations use `from orchestrator.forms.validators import organisation_contact_list` instead of this",
             },
             "contact_persons_org2": {
                 "items": {"$ref": "#/$defs/ContactPerson"},
@@ -71,6 +73,7 @@ def test_contact_persons_schema():
                 "organisationKey": "foo",
                 "title": "Contact Persons Org2",
                 "type": "array",
+                "description": "organisationId and organisationKey attributes will be removed, for version with organisations use `from orchestrator.forms.validators import organisation_contact_list` instead of this",
             },
         },
         "required": ["contact_persons", "contact_persons_org", "contact_persons_org2"],

--- a/tests/unit_tests/test_display_subscription.py
+++ b/tests/unit_tests/test_display_subscription.py
@@ -43,6 +43,7 @@ def test_display_only_schema():
                 "format": "subscription",
                 "title": "Display Sub",
                 "type": "string",
+                "description": "Use `from orchestrator.forms.validators import DisplaySubscription` instead of this",
             },
             "label": {
                 "anyOf": [{"type": "string"}, {"type": "null"}],

--- a/tests/unit_tests/test_organisation_id.py
+++ b/tests/unit_tests/test_organisation_id.py
@@ -8,7 +8,14 @@ def test_organisation_id_schema():
 
     expected = {
         "additionalProperties": False,
-        "properties": {"org_id": {"format": "organisationId", "title": "Org Id", "type": "string"}},
+        "properties": {
+            "org_id": {
+                "description": "Use `from orchestrator.forms.validators import CustomerId` instead of this",
+                "format": "organisationId",
+                "title": "Org Id",
+                "type": "string",
+            }
+        },
         "required": ["org_id"],
         "title": "unknown",
         "type": "object",


### PR DESCRIPTION
- deprecate DisplaySubscription and OrganisationId which are moved to orchestrator-core.
- add deprecation warning that organisation attributes will be removed from contact_person_list and the organisation version will go into orchestrator.