### PR TITLE
Change timestamp to annotated type

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.1
+current_version = 1.0.2
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((\-rc)(?P<build>\d+))?

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.10.0
+    rev: 24.2.0
     hooks:
       - id: black
         language_version: python3.9
@@ -8,10 +8,10 @@ repos:
     rev: 1.16.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==23.1.0]
+        additional_dependencies: [black==24.2.0]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.1.1
+    rev: v0.2.1
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix, --show-fixes ]
@@ -28,7 +28,7 @@ repos:
       - id: requirements-txt-fixer
       - id: detect-private-key
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.6.1
+    rev: v1.8.0
     hooks:
       - id: mypy
         language_version: python3.9

--- a/pydantic_forms/__init__.py
+++ b/pydantic_forms/__init__.py
@@ -13,4 +13,4 @@
 
 """This is the pydantic-forms engine."""
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/pydantic_forms/core/asynchronous.py
+++ b/pydantic_forms/core/asynchronous.py
@@ -126,8 +126,9 @@ async def start_form(
 
     try:
         state = await post_form(form, initial_state, user_inputs)
-    except FormValidationError:
-        logger.exception("Validation errors", user_inputs=user_inputs)
+    except FormValidationError as exc:
+        logger.debug("Validation errors", user_inputs=user_inputs, form=exc.validator_name, errors=exc.errors)
+        logger.debug(str(exc))
         raise
 
     return state

--- a/pydantic_forms/core/sync.py
+++ b/pydantic_forms/core/sync.py
@@ -121,8 +121,9 @@ def start_form(
 
     try:
         state = post_form(form, initial_state, user_inputs)
-    except FormValidationError:
-        logger.exception("Validation errors", user_inputs=user_inputs)
+    except FormValidationError as exc:
+        logger.debug("Validation errors", user_inputs=user_inputs, form=exc.validator_name, errors=exc.errors)
+        logger.debug(str(exc))
         raise
 
     return state

--- a/pydantic_forms/validators/components/contact_person_list.py
+++ b/pydantic_forms/validators/components/contact_person_list.py
@@ -10,6 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import warnings
 from typing import Annotated, Generator, Optional, TypeVar
 from uuid import UUID
 
@@ -33,12 +34,14 @@ def contact_person_list(
         if organisation_key:
             yield "organisationKey", organisation_key
 
+    warnings.warn(
+        "organisationId and organisationKey attributes will be removed, for version with organisation "
+        "(renamed to customer) use `from orchestrator.forms.validators import customer_contact_list` instead of this",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return Annotated[
         conlist(ContactPerson, min_length=min_items, max_length=max_items),
         BeforeValidator(remove_empty_items),
-        Field(
-            json_schema_extra=dict(json_schema_extra()),
-            deprecated=True,
-            description="organisationId and organisationKey attributes will be removed, for version with organisation (renamed to customer) use `from orchestrator.forms.validators import customer_contact_list` instead of this",
-        ),
+        Field(json_schema_extra=dict(json_schema_extra())),
     ]  # type: ignore

--- a/pydantic_forms/validators/components/display_subscription.py
+++ b/pydantic_forms/validators/components/display_subscription.py
@@ -15,12 +15,8 @@ from uuid import UUID
 
 from pydantic import Field
 
+# Deprecated, use `from orchestrator.forms.validators import DisplaySubscription` instead of this
 DisplaySubscription = Annotated[
     UUID,
-    Field(
-        frozen=True,
-        json_schema_extra={"format": "subscription", "type": "string"},
-        deprecated=True,
-        description="Use `from orchestrator.forms.validators import DisplaySubscription` instead of this",
-    ),
+    Field(frozen=True, json_schema_extra={"format": "subscription", "type": "string"}),
 ]

--- a/pydantic_forms/validators/components/organisation_id.py
+++ b/pydantic_forms/validators/components/organisation_id.py
@@ -14,11 +14,8 @@ from typing import Annotated
 
 from pydantic import Field
 
+# Deprecated, use `from orchestrator.forms.validators import CustomerId` instead of this
 OrganisationId = Annotated[
     str,
-    Field(
-        json_schema_extra={"format": "organisationId"},
-        deprecated=True,
-        description="Use `from orchestrator.forms.validators import CustomerId` instead of this",
-    ),
+    Field(json_schema_extra={"format": "organisationId"}),
 ]

--- a/pydantic_forms/validators/components/timestamp.py
+++ b/pydantic_forms/validators/components/timestamp.py
@@ -10,43 +10,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from types import new_class
-from typing import Any, ClassVar, Optional
+from typing import Annotated, Any, Optional
 
-from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
-from pydantic.json_schema import JsonSchemaValue
-from pydantic_core import CoreSchema, core_schema
-
-
-class Timestamp(int):
-    show_time_select: ClassVar[Optional[bool]] = True
-    locale: ClassVar[Optional[str]] = None  # example: nl-nl
-    min: ClassVar[Optional[int]] = None
-    max: ClassVar[Optional[int]] = None
-    date_format: ClassVar[Optional[str]] = None  # example: DD-MM-YYYY HH:mm
-    time_format: ClassVar[Optional[str]] = None  # example: HH:mm
-
-    @classmethod
-    def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler) -> CoreSchema:
-        return core_schema.no_info_after_validator_function(cls, handler(int))
-
-    @classmethod
-    def __get_pydantic_json_schema__(cls, core_schema: CoreSchema, handler: GetJsonSchemaHandler) -> JsonSchemaValue:
-        json_schema = handler(core_schema)
-        json_schema = handler.resolve_ref_schema(json_schema)
-        return json_schema | {
-            "format": "timestamp",
-            "type": "number",
-            "uniforms": {
-                # Using JS naming convention to increase DX on the JS side
-                "showTimeSelect": cls.show_time_select,
-                "locale": cls.locale,
-                "min": cls.min,
-                "max": cls.max,
-                "dateFormat": cls.date_format,
-                "timeFormat": cls.time_format,
-            },
-        }
+from pydantic import Field
 
 
 def timestamp(
@@ -56,13 +22,24 @@ def timestamp(
     max: Optional[int] = None,
     date_format: Optional[str] = None,
     time_format: Optional[str] = None,
-) -> type[Timestamp]:
-    namespace = {
-        "show_time_select": show_time_select,
-        "locale": locale,
-        "min": min,
-        "max": max,
-        "date_format": date_format,
-        "time_format": time_format,
-    }
-    return new_class("TimestampValue", (Timestamp,), {}, lambda ns: ns.update(namespace))
+) -> Any:
+    return Annotated[
+        int,
+        Field(
+            json_schema_extra={
+                "format": "timestamp",
+                "type": "number",
+                "uniforms": {
+                    "showTimeSelect": show_time_select,
+                    "locale": locale,
+                    "min": min,
+                    "max": max,
+                    "dateFormat": date_format,
+                    "timeFormat": time_format,
+                },
+            }
+        ),
+    ]
+
+
+Timestamp = timestamp()

--- a/tests/unit_tests/test_contact_person_list.py
+++ b/tests/unit_tests/test_contact_person_list.py
@@ -56,7 +56,6 @@ def test_contact_persons_schema():
                 "organisationKey": "organisation",
                 "title": "Contact Persons",
                 "type": "array",
-                "description": "organisationId and organisationKey attributes will be removed, for version with organisation (renamed to customer) use `from orchestrator.forms.validators import customer_contact_list` instead of this",
             },
             "contact_persons_org": {
                 "items": {"$ref": "#/$defs/ContactPerson"},
@@ -65,7 +64,6 @@ def test_contact_persons_schema():
                 "title": "Contact Persons Org",
                 "type": "array",
                 "minItems": 1,
-                "description": "organisationId and organisationKey attributes will be removed, for version with organisation (renamed to customer) use `from orchestrator.forms.validators import customer_contact_list` instead of this",
             },
             "contact_persons_org2": {
                 "items": {"$ref": "#/$defs/ContactPerson"},
@@ -73,7 +71,6 @@ def test_contact_persons_schema():
                 "organisationKey": "foo",
                 "title": "Contact Persons Org2",
                 "type": "array",
-                "description": "organisationId and organisationKey attributes will be removed, for version with organisation (renamed to customer) use `from orchestrator.forms.validators import customer_contact_list` instead of this",
             },
         },
         "required": ["contact_persons", "contact_persons_org", "contact_persons_org2"],

--- a/tests/unit_tests/test_display_subscription.py
+++ b/tests/unit_tests/test_display_subscription.py
@@ -43,7 +43,6 @@ def test_display_only_schema():
                 "format": "subscription",
                 "title": "Display Sub",
                 "type": "string",
-                "description": "Use `from orchestrator.forms.validators import DisplaySubscription` instead of this",
             },
             "label": {
                 "anyOf": [{"type": "string"}, {"type": "null"}],

--- a/tests/unit_tests/test_organisation_id.py
+++ b/tests/unit_tests/test_organisation_id.py
@@ -10,7 +10,6 @@ def test_organisation_id_schema():
         "additionalProperties": False,
         "properties": {
             "org_id": {
-                "description": "Use `from orchestrator.forms.validators import CustomerId` instead of this",
                 "format": "organisationId",
                 "title": "Org Id",
                 "type": "string",


### PR DESCRIPTION
* Change `timestamp()` from a custom type to an `Annotated[int]`
* Reduce validation errors loglevel from exception to debug
* Bump version to 1.0.2