### PR TITLE
Support metadata on FormPages

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.2
+current_version = 1.0.3
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((\-rc)(?P<build>\d+))?

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: pull-request-action
-        uses: vsoch/pull-request-action@1.0.13
+        uses: vsoch/pull-request-action@1.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_PREFIX: ""

--- a/pydantic_forms/__init__.py
+++ b/pydantic_forms/__init__.py
@@ -13,4 +13,4 @@
 
 """Pydantic-forms engine."""
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"

--- a/pydantic_forms/core/asynchronous.py
+++ b/pydantic_forms/core/asynchronous.py
@@ -85,7 +85,7 @@ async def post_form(
         return generated_form
 
     # Form is not completely filled raise next form
-    raise FormNotCompleteError(generated_form.model_json_schema())
+    raise FormNotCompleteError(generated_form.model_json_schema(), meta=getattr(generated_form, "meta__", None))
 
 
 def _get_form(key: str) -> StateInputFormGeneratorAsync:

--- a/pydantic_forms/core/sync.py
+++ b/pydantic_forms/core/sync.py
@@ -65,7 +65,7 @@ def post_form(form_generator: Union[StateInputFormGenerator, None], state: State
             try:
                 form_validated_data = generated_form(**user_input)
             except ValidationError as e:
-                raise FormValidationError(generated_form.__name__, e) from e  # type: ignore
+                raise FormValidationError(generated_form.__name__, e) from e
 
             # Update state with validated_data
             current_state.update(form_validated_data.model_dump())
@@ -74,7 +74,7 @@ def post_form(form_generator: Union[StateInputFormGenerator, None], state: State
             generated_form = generator.send(form_validated_data)
 
         # Form is not completely filled; raise next form
-        raise FormNotCompleteError(generated_form.model_json_schema())
+        raise FormNotCompleteError(generated_form.model_json_schema(), meta=getattr(generated_form, "meta__", None))
     except StopIteration as e:
         if user_inputs:
             raise FormOverflowError(f"Did not process all user_inputs ({len(user_inputs)} remaining)")

--- a/pydantic_forms/exception_handlers/fastapi.py
+++ b/pydantic_forms/exception_handlers/fastapi.py
@@ -48,6 +48,7 @@ async def form_error_handler(request: Request, exc: FormException) -> JSONRespon
                 "form": json_loads(json_dumps(exc.form)),
                 "title": "Form not complete",
                 "status": HTTPStatus.NOT_EXTENDED,
+                "meta": getattr(exc, "meta")
             },
             status_code=HTTPStatus.NOT_EXTENDED,
         )

--- a/pydantic_forms/exception_handlers/fastapi.py
+++ b/pydantic_forms/exception_handlers/fastapi.py
@@ -48,7 +48,7 @@ async def form_error_handler(request: Request, exc: FormException) -> JSONRespon
                 "form": json_loads(json_dumps(exc.form)),
                 "title": "Form not complete",
                 "status": HTTPStatus.NOT_EXTENDED,
-                "meta": getattr(exc, "meta")
+                "meta": getattr(exc, "meta", None),
             },
             status_code=HTTPStatus.NOT_EXTENDED,
         )

--- a/pydantic_forms/exceptions.py
+++ b/pydantic_forms/exceptions.py
@@ -1,5 +1,5 @@
 import traceback
-from typing import Any, Iterable, TypedDict, Union, cast
+from typing import Any, Iterable, Optional, TypedDict, Union, cast
 
 from more_itertools import side_effect
 from pydantic import ValidationError
@@ -19,9 +19,9 @@ class FormNotCompleteError(FormException):
     """
 
     form: JSON
-    meta: JSON | None
+    meta: Optional[JSON]
 
-    def __init__(self, form: JSON, *, meta: JSON | None = None):
+    def __init__(self, form: JSON, *, meta: Optional[JSON] = None):
         super().__init__(form)
         self.form = form
         self.meta = meta

--- a/pydantic_forms/exceptions.py
+++ b/pydantic_forms/exceptions.py
@@ -21,7 +21,7 @@ class FormNotCompleteError(FormException):
     form: JSON
     meta: JSON | None
 
-    def __init__(self, form: JSON, meta: JSON | None):
+    def __init__(self, form: JSON, *, meta: JSON | None = None):
         super().__init__(form)
         self.form = form
         self.meta = meta

--- a/pydantic_forms/exceptions.py
+++ b/pydantic_forms/exceptions.py
@@ -19,10 +19,12 @@ class FormNotCompleteError(FormException):
     """
 
     form: JSON
+    meta: JSON | None
 
-    def __init__(self, form: JSON):
+    def __init__(self, form: JSON, meta: JSON | None):
         super().__init__(form)
         self.form = form
+        self.meta = meta
 
 
 class FormOverflowError(FormException):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ classifiers = [
 ]
 requires = [
     "more-itertools",
-    "pydantic[email] >= 2.5.1",
+    "pydantic[email] ~= 2.5.1",
+    "pydantic~=2.5.1"
 ]
 description-file = "README.md"
 requires-python = ">=3.9,<=3.13"

--- a/tests/unit_tests/test_accept.py
+++ b/tests/unit_tests/test_accept.py
@@ -1,3 +1,5 @@
+from unittest.mock import ANY
+
 from pydantic_core import ValidationError
 from pytest import raises
 
@@ -28,6 +30,7 @@ def test_accept_schema():
                 "format": "accept",
                 "type": "string",
                 "title": "Accept",
+                "metadata": ANY,
             }
         },
         "required": ["accept"],
@@ -54,6 +57,7 @@ def test_accept_schema_with_data():
                 "format": "accept",
                 "type": "string",
                 "title": "Accept",
+                "metadata": ANY,
             }
         },
         "required": ["accept"],


### PR DESCRIPTION
Allow adding metadata on FormPages. A use case is for communicating presentation details to the frontend without affecting the existing properties, serialization or validation.

To do this, create a `ClassVar[JSON]` field on a FormPage class.