### PR TITLE
Add `validate=` param to `timestamp()` for backwards compatibility

### DIFF
--- a/pydantic_forms/validators/components/timestamp.py
+++ b/pydantic_forms/validators/components/timestamp.py
@@ -19,29 +19,30 @@ from pydantic import Field
 def timestamp(
     show_time_select: Optional[bool] = True,
     locale: Optional[str] = None,
+    validate: bool = True,  # Set to False to disable min/max validation
     min: Optional[int] = None,
     max: Optional[int] = None,
     date_format: Optional[str] = None,
     time_format: Optional[str] = None,
 ) -> Any:
-    return Annotated[
-        int,
-        Interval(ge=min, le=max),
-        Field(
-            json_schema_extra={
-                "format": "timestamp",
-                "type": "number",
-                "uniforms": {
-                    "showTimeSelect": show_time_select,
-                    "locale": locale,
-                    "min": min,
-                    "max": max,
-                    "dateFormat": date_format,
-                    "timeFormat": time_format,
-                },
-            }
-        ),
-    ]
+    schema = Field(
+        json_schema_extra={
+            "format": "timestamp",
+            "type": "number",
+            "uniforms": {
+                "showTimeSelect": show_time_select,
+                "locale": locale,
+                "min": min,
+                "max": max,
+                "dateFormat": date_format,
+                "timeFormat": time_format,
+            },
+        }
+    )
+
+    if validate:
+        return Annotated[int, Interval(ge=min, le=max), schema]
+    return Annotated[int, schema]
 
 
 Timestamp = timestamp()

--- a/tests/unit_tests/test_timestamp.py
+++ b/tests/unit_tests/test_timestamp.py
@@ -55,18 +55,19 @@ def test_timestamp_schema():
 
 
 @pytest.mark.parametrize(
-    "min_value,max_value,input_value,expectation",
+    "min_value,max_value,input_value,validate,expectation",
     [
-        (1652751600, 1652751601, 1652751599, pytest.raises(ValidationError, match="greater")),
-        (1652751600, 1652751601, 1652751600, nullcontext(1652751600)),
-        (1652751600, 1652751601, 1652751601, nullcontext(1652751601)),
-        (1652751600, 1652751601, 1652751602, pytest.raises(ValidationError, match="less")),
-        (1652751600, None, 1652751600, nullcontext(1652751600)),
-        (1652751600, None, 1652751599, pytest.raises(ValidationError, match="greater")),
+        (1652751600, 1652751601, 1652751599, True, pytest.raises(ValidationError, match="greater")),
+        (1652751600, 1652751601, 1652751600, True, nullcontext(1652751600)),
+        (1652751600, 1652751601, 1652751601, True, nullcontext(1652751601)),
+        (1652751600, 1652751601, 1652751602, True, pytest.raises(ValidationError, match="less")),
+        (1652751600, None, 1652751600, True, nullcontext(1652751600)),
+        (1652751600, None, 1652751599, True, pytest.raises(ValidationError, match="greater")),
+        (1652751600, None, 1652751599, False, nullcontext(1652751599)),  # backwards compatibility
     ],
 )
-def test_timestamp_validation(min_value, max_value, input_value, expectation):
-    adapter = TypeAdapter(timestamp(min=min_value, max=max_value))
+def test_timestamp_validation(min_value, max_value, input_value, validate, expectation):
+    adapter = TypeAdapter(timestamp(min=min_value, max=max_value, validate=validate))
 
     with expectation as expected_result:
         assert adapter.validate_python(input_value) == expected_result


### PR DESCRIPTION
Allow explicitly disabling timestamp validation with `timestamp(min=not_before, max_before=not_after, validate=False)`.
I.e. when custom validation messages for exceeding the `min/max` value are required.