### PR TITLE
Fix FormPage frozen field handling + Add more pydantic versions to test matrix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.1
+current_version = 2.1.2
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((\-rc)(?P<build>\d+))?

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   container_job:
-    name: Unit tests
+    name: Unit tests (Python ${{ matrix.python-version }}, Pydantic ${{ matrix.pydantic-version }}, FastAPI ${{ matrix.fastapi-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -14,23 +14,31 @@ jobs:
         fastapi-version: ['lockfile']
         # Test specific older releases to avoid an extremely large test matrix
         include:
-          # Older pydantic releases
+          # Older pydantic releases with the oldest + latest supported python version
           - python-version: '3.13'
             pydantic-version: '2.10.6'
+            fastapi-version: 'lockfile'
           - python-version: '3.9'
             pydantic-version: '2.10.6'
+            fastapi-version: 'lockfile'
           - python-version: '3.13'
             pydantic-version: '2.9.2'
+            fastapi-version: 'lockfile'
           - python-version: '3.9'
             pydantic-version: '2.9.2'
+            fastapi-version: 'lockfile'
           - python-version: '3.13'
             pydantic-version: '2.8.2'
+            fastapi-version: 'lockfile'
           - python-version: '3.9'
             pydantic-version: '2.8.2'
-          # Older fastapi releases
+            fastapi-version: 'lockfile'
+          # Older fastapi releases with the oldest + latest supported python version
           - python-version: '3.13'
+            pydantic-version: 'lockfile'
             fastapi-version: '0.103.2'
           - python-version: '3.9'
+            pydantic-version: 'lockfile'
             fastapi-version: '0.103.2'
       fail-fast: false
     container: python:${{ matrix.python-version }}-slim

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -11,7 +11,27 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         pydantic-version: ['lockfile']
-        fastapi-version: ['0.103.2', 'lockfile']
+        fastapi-version: ['lockfile']
+        # Test specific older releases to avoid an extremely large test matrix
+        include:
+          # Older pydantic releases
+          - python-version: '3.13'
+            pydantic-version: '2.10.6'
+          - python-version: '3.9'
+            pydantic-version: '2.10.6'
+          - python-version: '3.13'
+            pydantic-version: '2.9.2'
+          - python-version: '3.9'
+            pydantic-version: '2.9.2'
+          - python-version: '3.13'
+            pydantic-version: '2.8.2'
+          - python-version: '3.9'
+            pydantic-version: '2.8.2'
+          # Older fastapi releases
+          - python-version: '3.13'
+            fastapi-version: '0.103.2'
+          - python-version: '3.9'
+            fastapi-version: '0.103.2'
       fail-fast: false
     container: python:${{ matrix.python-version }}-slim
     steps:

--- a/pydantic_forms/__init__.py
+++ b/pydantic_forms/__init__.py
@@ -13,4 +13,4 @@
 
 """Pydantic-forms engine."""
 
-__version__ = "2.1.1"
+__version__ = "2.1.2"

--- a/pydantic_forms/core/shared.py
+++ b/pydantic_forms/core/shared.py
@@ -32,7 +32,7 @@ class FormPage(BaseModel):
     )
 
     def __init__(self, **data: Any):
-        frozen_fields = {k: v for k, v in self.model_fields.items() if v.frozen}
+        frozen_fields = {k: v for k, v in self.__class__.model_fields.items() if v.frozen}
 
         def get_value(k: str, v: Any) -> Any:
             if k in frozen_fields:
@@ -47,10 +47,14 @@ class FormPage(BaseModel):
         # The default and requiredness of a field is not a property of a field
         # In the case of DisplayOnlyFieldTypes, we do kind of want that.
         # Using this method we set the right properties after the form is created
-
+        needs_rebuild = False
         for field in cls.model_fields.values():
             if field.frozen:
                 field.validate_default = False
+                needs_rebuild = True
+
+        if needs_rebuild:
+            cls.model_rebuild(force=True)
 
 
 FORMS: dict[str, Callable] = {}

--- a/pydantic_forms/core/shared.py
+++ b/pydantic_forms/core/shared.py
@@ -14,7 +14,7 @@ from inspect import isasyncgenfunction, isgeneratorfunction
 from typing import Any, Callable
 
 import structlog
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, PydanticUndefinedAnnotation
 
 logger = structlog.get_logger(__name__)
 
@@ -48,13 +48,29 @@ class FormPage(BaseModel):
         # In the case of DisplayOnlyFieldTypes, we do kind of want that.
         # Using this method we set the right properties after the form is created
         needs_rebuild = False
+
         for field in cls.model_fields.values():
             if field.frozen:
                 field.validate_default = False
                 needs_rebuild = True
 
         if needs_rebuild:
-            cls.model_rebuild(force=True)
+            try:
+                # Fix for #39:
+                # Core schema used during validation is constructed before __pydantic_init_subclass__ which means
+                # that the field.validate_default change above doesn't take effect.
+                # As a workaround, we explicitly rebuild the model to reconstruct the core schema.
+                #
+                # Downside is that unresolved forward-refs trigger an exception; for now we catch/log/ignore it.
+                # From pydantic 2.12 a new hook __pydantic_on_complete__ can be used to perform the rebuild instead.
+                # https://github.com/pydantic/pydantic/pull/11762
+                cls.model_rebuild(force=True)
+            except PydanticUndefinedAnnotation as exc:
+                logger.warning(
+                    "Failed to rebuild model due to undefined annotation, frozen fields may not work as expected",
+                    undefined_annotation=exc.name,
+                    model=cls.__name__,
+                )
 
 
 FORMS: dict[str, Callable] = {}

--- a/tests/unit_tests/helpers.py
+++ b/tests/unit_tests/helpers.py
@@ -1,3 +1,8 @@
+import pydantic.version
+
+PYDANTIC_VERSION = pydantic.version.version_short()
+
+
 def assert_equal_ignore_key(expected, actual, ignore_keys):
     def deep_remove_keys(d, keys_to_ignore):
         if isinstance(d, dict):

--- a/tests/unit_tests/test_choice_list.py
+++ b/tests/unit_tests/test_choice_list.py
@@ -4,6 +4,8 @@ from pydantic_core import ValidationError
 from pydantic_forms.core import FormPage
 from pydantic_forms.validators import Choice, choice_list
 
+from tests.unit_tests.helpers import PYDANTIC_VERSION
+
 
 def test_choice_list():
     class LegChoice(Choice):
@@ -149,13 +151,17 @@ def test_choice_list_constraint_at_least_one_item(Form):
         Form(choice=[])
 
     errors = exc_info.value.errors(include_url=False, include_context=False)
+
+    if PYDANTIC_VERSION == "2.8":
+        message = "List should have at least 1 item after validation, not 0"
+    else:
+        message = "Value should have at least 1 item after validation, not 0"
     expected = [
         {
             "input": [],
             "loc": ("choice",),
-            "msg": "Value should have at least 1 item after validation, not 0",
+            "msg": message,
             "type": "too_short",
-            # "ctx": {"limit_value": 1},
         }
     ]
     assert errors == expected

--- a/tests/unit_tests/test_constrained_list.py
+++ b/tests/unit_tests/test_constrained_list.py
@@ -3,6 +3,9 @@ from pytest import raises
 
 from pydantic_forms.core import FormPage
 from pydantic_forms.validators import unique_conlist
+from pydantic.version import version_short as pydantic_version_short
+
+from tests.unit_tests.helpers import PYDANTIC_VERSION
 
 
 def test_constrained_list_good():
@@ -74,12 +77,15 @@ def test_constrained_list_too_short():
 
     errors = exc_info.value.errors(include_url=False, include_context=False)
 
+    if PYDANTIC_VERSION == "2.8":
+        message = "List should have at least 1 item after validation, not 0"
+    else:
+        message = "Value should have at least 1 item after validation, not 0"
     expected = [
         {
-            # "ctx": {"error": ListMinLengthError(limit_value=1)},
             "input": [],
             "loc": ("v",),
-            "msg": "Value should have at least 1 item after validation, not 0",
+            "msg": message,
             "type": "too_short",
         }
     ]
@@ -111,11 +117,15 @@ def test_constrained_list_inherit_constraints():
         UniqueConListModel(v=[])
 
     errors = exc_info.value.errors(include_url=False, include_context=False)
+    if PYDANTIC_VERSION == "2.8":
+        message = "List should have at least 1 item after validation, not 0"
+    else:
+        message = "Value should have at least 1 item after validation, not 0"
     assert errors == [
         {
             "input": [],
             "loc": ("v",),
-            "msg": "Value should have at least 1 item after validation, not 0",
+            "msg": message,
             "type": "too_short",
             # "ctx": {"limit_value": 1},
         }

--- a/tests/unit_tests/test_display_subscription.py
+++ b/tests/unit_tests/test_display_subscription.py
@@ -2,6 +2,7 @@ from uuid import uuid4
 
 from pydantic_forms.core import FormPage
 from pydantic_forms.validators import DisplaySubscription, Label, migration_summary
+from tests.unit_tests.helpers import PYDANTIC_VERSION
 
 
 def test_display_subscription():
@@ -35,6 +36,11 @@ def test_display_only_schema():
         label: Label
         summary: Summary
 
+    if PYDANTIC_VERSION == "2.8":
+        summary_ref = {"allOf": [{"$ref": "#/$defs/MigrationSummaryValue"}]}
+    else:
+        summary_ref = {"$ref": "#/$defs/MigrationSummaryValue"}
+
     expected = {
         "$defs": {"MigrationSummaryValue": {"properties": {}, "title": "MigrationSummaryValue", "type": "object"}},
         "additionalProperties": False,
@@ -53,7 +59,7 @@ def test_display_only_schema():
                 "type": "string",
             },
             "summary": {
-                "$ref": "#/$defs/MigrationSummaryValue",
+                **summary_ref,
                 "default": None,
                 "format": "summary",
                 "type": "string",

--- a/tests/unit_tests/test_list_of_two.py
+++ b/tests/unit_tests/test_list_of_two.py
@@ -3,6 +3,7 @@ from pydantic import ValidationError
 
 from pydantic_forms.core import FormPage
 from pydantic_forms.validators import ListOfTwo
+from tests.unit_tests.helpers import PYDANTIC_VERSION
 
 
 @pytest.fixture(name="Form")
@@ -22,11 +23,15 @@ def test_list_of_two_min_items(Form):
         assert Form(two=[1])
 
     errors = error_info.value.errors(include_url=False, include_context=False)
+    if PYDANTIC_VERSION == "2.8":
+        message = "List should have at least 2 items after validation, not 1"
+    else:
+        message = "Value should have at least 2 items after validation, not 1"
     expected = [
         {
             "input": [1],
             "loc": ("two",),
-            "msg": "Value should have at least 2 items after validation, not 1",
+            "msg": message,
             "type": "too_short",
         }
     ]
@@ -38,11 +43,15 @@ def test_list_of_two_max_items(Form):
         assert Form(two=[1, 2, 3])
 
     errors = error_info.value.errors(include_url=False, include_context=False)
+    if PYDANTIC_VERSION == "2.8":
+        message = "List should have at most 2 items after validation, not 3"
+    else:
+        message = "Value should have at most 2 items after validation, not 3"
     expected = [
         {
             "input": [1, 2, 3],
             "loc": ("two",),
-            "msg": "Value should have at most 2 items after validation, not 3",
+            "msg": message,
             "type": "too_long",
         },
     ]

--- a/tests/unit_tests/test_migration_summary.py
+++ b/tests/unit_tests/test_migration_summary.py
@@ -2,6 +2,7 @@ from uuid import uuid4
 
 from pydantic_forms.core import FormPage
 from pydantic_forms.validators import DisplaySubscription, Label, migration_summary
+from tests.unit_tests.helpers import PYDANTIC_VERSION
 
 
 def test_display_default():
@@ -33,12 +34,17 @@ def test_migration_summary_schema():
     class Form(FormPage):
         ms: Summary
 
+    if PYDANTIC_VERSION == "2.8":
+        ms_ref = {"allOf": [{"$ref": "#/$defs/MigrationSummaryValue"}]}
+    else:
+        ms_ref = {"$ref": "#/$defs/MigrationSummaryValue"}
+
     expected = {
         "$defs": {"MigrationSummaryValue": {"properties": {}, "title": "MigrationSummaryValue", "type": "object"}},
         "additionalProperties": False,
         "properties": {
             "ms": {
-                "$ref": "#/$defs/MigrationSummaryValue",
+                **ms_ref,
                 "default": None,
                 "format": "summary",
                 "type": "string",

--- a/tests/unit_tests/test_read_only_field.py
+++ b/tests/unit_tests/test_read_only_field.py
@@ -5,6 +5,8 @@ from pydantic.config import JsonDict
 import pytest
 from pydantic import BaseModel, ValidationError
 
+from pydantic.version import version_short as pydantic_version_short
+
 from pydantic_forms.core import FormPage
 from pydantic_forms.types import strEnum
 from pydantic_forms.validators import read_only_field, read_only_list, LongText, OrganisationId
@@ -48,7 +50,13 @@ def test_read_only_field_schema(read_only_value, schema_value, schema_type, othe
         "additionalProperties": False,
     }
 
-    assert Form.model_json_schema() == expected
+    actual = Form.model_json_schema()
+
+    if pydantic_version_short() in ("2.8", "2.9"):
+        # Behavior that was changed (fixed) in 2.10 https://github.com/pydantic/pydantic/pull/10692
+        del actual["properties"]["read_only"]["enum"]
+
+    assert actual == expected
 
     validated = Form(read_only=read_only_value)
     assert validated.read_only == read_only_value

--- a/tests/unit_tests/test_shared.py
+++ b/tests/unit_tests/test_shared.py
@@ -1,0 +1,33 @@
+import pytest
+from pydantic import Field
+from pydantic_core import ValidationError
+
+from pydantic_forms.core import FormPage
+
+
+def test_formpage_field_defaults_are_validated():
+    """Test that default values in the FormPage class are validated."""
+
+    class TestForm(FormPage):
+        x: int = "foo"
+
+    with pytest.raises(ValidationError):
+        _ = TestForm().model_dump()
+
+
+def test_formpage_frozen_field_default_not_validated():
+    """Test that default values in the FormPage class are not validated when the field is frozen."""
+
+    class TestForm(FormPage):
+        x: int = Field("foo", frozen=True)
+
+    assert TestForm().model_dump() == {"x": "foo"}
+
+
+def test_formpage_frozen_field_uses_default():
+    """Test that default values in the FormPage class take precedence over the input value."""
+
+    class TestForm(FormPage):
+        x: int = Field(1, frozen=True)
+
+    assert TestForm(x=2).model_dump() == {"x": 1}

--- a/tests/unit_tests/test_shared.py
+++ b/tests/unit_tests/test_shared.py
@@ -1,17 +1,24 @@
+from typing import Annotated
+
 import pytest
-from pydantic import Field
+from pydantic import Field, BaseModel
 from pydantic_core import ValidationError
 
 from pydantic_forms.core import FormPage
+
+
+def regex_field_should_be_int(field_name: str) -> str:
+    # Multiline regex to match pydantic's validation error for an int field
+    return rf"(?m)\n{field_name}\n\s+Input should be a valid integer"
 
 
 def test_formpage_field_defaults_are_validated():
     """Test that default values in the FormPage class are validated."""
 
     class TestForm(FormPage):
-        x: int = "foo"
+        int_field: int = "foo"
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match=regex_field_should_be_int("int_field")):
         _ = TestForm().model_dump()
 
 
@@ -19,15 +26,53 @@ def test_formpage_frozen_field_default_not_validated():
     """Test that default values in the FormPage class are not validated when the field is frozen."""
 
     class TestForm(FormPage):
-        x: int = Field("foo", frozen=True)
+        int_field: int = Field("foo", frozen=True)
 
-    assert TestForm().model_dump() == {"x": "foo"}
+    assert TestForm().model_dump() == {"int_field": "foo"}
+
+
+class TestFormWithForwardRef(FormPage):
+    # Needs to be at module level for the forward-ref stuff to work
+    bar_field: "Bar"
+    int_field: int = "foo"
+
+
+class TestFormWithForwardRefAndFrozenField(FormPage):
+    # Needs to be at module level for the forward-ref stuff to work
+    bar_field: "Bar"
+    int_field: int = Field("foo", frozen=True)
+
+
+class Bar(FormPage):
+    sub_int_field: int
+
+
+def test_formpage_with_forward_ref():
+    """Test that default values in the FormPage class are validated when there is a forward-ref field."""
+    with pytest.raises(ValidationError, match=regex_field_should_be_int("int_field")):
+        _ = TestFormWithForwardRef(bar_field={"sub_int_field": 3}).model_dump()
+
+
+def test_formpage_with_forward_ref_and_frozen_field():
+    """Test that default values in the FormPage class are not validated when one field is frozen and another is an
+    unresolved forward-ref.
+
+    Relates to issue #39 which revealed that the way we previously changed `validate_default=False` for frozen
+    fields did not work. The workaround implemented was to call `model_rebuild()` in __pydantic_init_subclass__, but the
+    problem with that is it raises a PydanticUndefinedAnnotation for unresolved forward-refs.
+
+    In that case, the FormPage should catch the exception and proceed.
+    """
+    assert TestFormWithForwardRefAndFrozenField(bar_field={"sub_int_field": 3}).model_dump() == {
+        "bar_field": {"sub_int_field": 3},
+        "int_field": "foo",
+    }
 
 
 def test_formpage_frozen_field_uses_default():
     """Test that default values in the FormPage class take precedence over the input value."""
 
     class TestForm(FormPage):
-        x: int = Field(1, frozen=True)
+        int_field: int = Field(1, frozen=True)
 
-    assert TestForm(x=2).model_dump() == {"x": 1}
+    assert TestForm(int_field=2).model_dump() == {"int_field": 1}


### PR DESCRIPTION
Changes to `FormPage`:
* Rebuild the model to persist changes to `field.validate_default` for frozen fields
  * Catch/log/ignore undefined annotations in case of unresolved forward-refs, add note on new hook `__pydantic_on_complete` we can use from 2.12 onward
* Access the model's `model_fields` through the class instead of the instance

CI/general changes:
* Test not just latest pydantic (currently 2.11) but also 2.8/2.9/2.10 + Update expected schemas in unittests based on the pydantic version

Closes #39 