### PR TITLE
Add functions to validate the length of a list

### DIFF
--- a/pydantic_forms/validators/__init__.py
+++ b/pydantic_forms/validators/__init__.py
@@ -7,6 +7,7 @@ from pydantic_forms.validators.components.display_subscription import DisplaySub
 from pydantic_forms.validators.components.divider import Divider
 from pydantic_forms.validators.components.hidden import Hidden
 from pydantic_forms.validators.components.label import Label
+from pydantic_forms.validators.components.list import ItemLength, MinItems, MaxItems
 from pydantic_forms.validators.components.list_of_one import ListOfOne
 from pydantic_forms.validators.components.list_of_two import ListOfTwo
 from pydantic_forms.validators.components.long_text import LongText
@@ -27,12 +28,15 @@ __all__ = (
     "DisplaySubscription",
     "Divider",
     "Hidden",
+    "ItemLength",
     "Label",
     "ListOfOne",
     "ListOfTwo",
     "LongText",
     "migration_summary",
     "MigrationSummary",
+    "MinItems",
+    "MaxItems",
     "OrganisationId",
     "read_only_field",
     "read_only_list",

--- a/pydantic_forms/validators/components/list.py
+++ b/pydantic_forms/validators/components/list.py
@@ -1,0 +1,33 @@
+# Copyright 2019-2023 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TypeVar
+
+from pydantic import Field
+
+T = TypeVar("T")
+
+
+def MinItems(min_items: int):
+    """Annotator for minimum number of items in a list."""
+    return Field(min_items=min_items)
+
+
+def MaxItems(max_items: int):
+    """Annotator for maximum number of items in a list."""
+    return Field(max_items=max_items)
+
+
+def ItemLength(min_items: int | None = None, max_items: int | None = None):
+    """Annotator for both minimum and maximum number of items."""
+    return Field(min_items=min_items, max_items=max_items)

--- a/tests/unit_tests/test_list_item_lenght.py
+++ b/tests/unit_tests/test_list_item_lenght.py
@@ -1,0 +1,54 @@
+from typing import Annotated
+
+import pytest
+from pydantic import ValidationError
+
+from pydantic_forms.core import FormPage
+from pydantic_forms.validators import MinItems, ItemLength
+
+
+@pytest.fixture(name="Form")
+def form_with_list_with_min_one_item():
+    class _Form(FormPage):
+        items: Annotated[
+            list[int],
+            ItemLength(2,3)
+        ]
+
+    return _Form
+
+
+def test_list_with_one_item_ok(Form):
+    assert Form(items=[1,2])
+
+def test_list_with_more_items_nok(Form):
+    with pytest.raises(ValidationError) as error_info:
+        assert Form(items=[1,2,3,4])
+
+    errors = error_info.value.errors(include_url=False, include_context=False)
+    expected = [
+        {
+            "input": [1,2,3,4],
+            "loc": ("items",),
+            "msg": "List should have at most 3 items after validation, not 4",
+            "type": "too_long",
+        },
+    ]
+    assert errors == expected
+
+def test_list_with_less_items_nok(Form):
+    with pytest.raises(ValidationError) as error_info:
+        assert Form(items=[1])
+
+    errors = error_info.value.errors(include_url=False, include_context=False)
+    expected = [
+        {
+            'input': [1],
+            'loc': ('items',),
+            'msg': 'List should have at least 2 items after validation, not 1',
+            'type': 'too_short'
+        }
+    ]
+    assert errors == expected
+
+

--- a/tests/unit_tests/test_list_max_items.py
+++ b/tests/unit_tests/test_list_max_items.py
@@ -1,0 +1,38 @@
+from typing import Annotated
+
+import pytest
+from pydantic import ValidationError
+
+from pydantic_forms.core import FormPage
+from pydantic_forms.validators import MaxItems
+
+
+@pytest.fixture(name="Form")
+def form_with_list_with_max_one_item():
+    class _Form(FormPage):
+        max_one: Annotated[
+            list[int],
+            MaxItems(1)
+        ]
+
+    return _Form
+
+
+def test_list_list_with_max_one_item_ok(Form):
+    assert Form(max_one=[1])
+
+def test_list_list_with_max_one_item_more_nok(Form):
+    with pytest.raises(ValidationError) as error_info:
+        assert Form(max_one=[1,2])
+
+    errors = error_info.value.errors(include_url=False, include_context=False)
+    expected = [
+        {
+            "input": [1, 2],
+            "loc": ("max_one",),
+            "msg": "List should have at most 1 item after validation, not 2",
+            "type": "too_long",
+        },
+    ]
+    assert errors == expected
+

--- a/tests/unit_tests/test_list_min_items.py
+++ b/tests/unit_tests/test_list_min_items.py
@@ -1,0 +1,38 @@
+from typing import Annotated
+
+import pytest
+from pydantic import ValidationError
+
+from pydantic_forms.core import FormPage
+from pydantic_forms.validators import MinItems
+
+
+@pytest.fixture(name="Form")
+def form_with_list_with_min_one_item():
+    class _Form(FormPage):
+        min_one: Annotated[
+            list[int],
+            MinItems(1)
+        ]
+
+    return _Form
+
+
+def test_list_list_with_min_one_item_ok(Form):
+    assert Form(min_one=[1])
+
+def test_list_list_with_min_one_item_less_nok(Form):
+    with pytest.raises(ValidationError) as error_info:
+        assert Form(min_one=[])
+
+    errors = error_info.value.errors(include_url=False, include_context=False)
+    expected = [
+        {
+            "input": [],
+            "loc": ("min_one",),
+            "msg": "List should have at least 1 item after validation, not 0",
+            "type": "too_short",
+        },
+    ]
+    assert errors == expected
+


### PR DESCRIPTION
This PR implements a validation component for lists in Pydantic-based forms, integrating with existing annotators like `MinItem`and `MaxItems`. It provides constraints for list lengths as part of the validators/components system. 
