### PR TITLE
Add form key 'extraProperties' and deprecate 'uniforms'

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.3.0
+current_version = 2.4.0
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((\-rc)(?P<build>\d+))?

--- a/pydantic_forms/__init__.py
+++ b/pydantic_forms/__init__.py
@@ -13,4 +13,4 @@
 
 """Pydantic-forms engine."""
 
-__version__ = "2.3.0"
+__version__ = "2.4.0"

--- a/pydantic_forms/validators/components/migration_summary.py
+++ b/pydantic_forms/validators/components/migration_summary.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 SURF.
+# Copyright 2019-2026 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -17,6 +17,7 @@ from typing import Annotated, Any, ClassVar, Optional
 from pydantic import BaseModel, Field
 
 from pydantic_forms.types import SummaryData
+from pydantic_forms.validators import constants
 
 
 class _MigrationSummary(BaseModel):
@@ -27,7 +28,15 @@ MigrationSummary = Annotated[_MigrationSummary, Field(frozen=True, default=None,
 
 
 def create_json_extra_schema(data: SummaryData, schema: dict[str, Any]) -> None:
-    schema.update({"format": "summary", "type": "string", "uniforms": {"data": data}})
+    forms_schema = {"data": data}
+    schema.update(
+        {
+            "format": "summary",
+            "type": "string",
+            "uniforms": forms_schema,  # Deprecated
+            constants.EXTRA_PROPERTIES: forms_schema,
+        }
+    )
 
 
 def migration_summary(data: SummaryData) -> type[MigrationSummary]:

--- a/pydantic_forms/validators/components/read_only.py
+++ b/pydantic_forms/validators/components/read_only.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 SURF, ESnet.
+# Copyright 2019-2026 SURF, ESnet.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -22,6 +22,7 @@ from pydantic import AfterValidator, BeforeValidator, Field, PlainSerializer, Ty
 
 from pydantic_forms.types import strEnum
 from pydantic_forms.utils.schema import merge_json_schema
+from pydantic_forms.validators import constants
 
 # from pydantic.json_schema
 JSON_SCHEMA_TYPES = {
@@ -56,7 +57,12 @@ def _get_json_type(default: Any) -> str:
 
 def _get_read_only_schema(default: Any) -> dict:
     """Get base schema dict object for uniforms."""
-    return {"uniforms": {"disabled": True, "value": default}, "type": _get_json_type(default)}
+    forms_schema = {"disabled": True, "value": default}
+    return {
+        "uniforms": forms_schema,  # Deprecated
+        constants.EXTRA_PROPERTIES: forms_schema,
+        "type": _get_json_type(default),
+    }
 
 
 def read_only_list(default: list[Any] | None = None) -> Any:

--- a/pydantic_forms/validators/components/timestamp.py
+++ b/pydantic_forms/validators/components/timestamp.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 SURF.
+# Copyright 2019-2026 SURF.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -14,6 +14,9 @@ from typing import Annotated, Any, Optional
 
 from annotated_types import Interval
 from pydantic import Field
+from pydantic.config import JsonDict
+
+from pydantic_forms.validators import constants
 
 
 def timestamp(
@@ -25,18 +28,20 @@ def timestamp(
     date_format: Optional[str] = None,
     time_format: Optional[str] = None,
 ) -> Any:
+    forms_schema: JsonDict = {
+        "showTimeSelect": show_time_select,
+        "locale": locale,
+        "min": min,
+        "max": max,
+        "dateFormat": date_format,
+        "timeFormat": time_format,
+    }
     schema = Field(
         json_schema_extra={
             "format": "timestamp",
             "type": "number",
-            "uniforms": {
-                "showTimeSelect": show_time_select,
-                "locale": locale,
-                "min": min,
-                "max": max,
-                "dateFormat": date_format,
-                "timeFormat": time_format,
-            },
+            "uniforms": forms_schema,  # Deprecated
+            constants.EXTRA_PROPERTIES: forms_schema,
         }
     )
 

--- a/pydantic_forms/validators/constants.py
+++ b/pydantic_forms/validators/constants.py
@@ -1,0 +1,14 @@
+# Copyright 2019-2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+EXTRA_PROPERTIES = "extraProperties"

--- a/tests/unit_tests/test_display_subscription.py
+++ b/tests/unit_tests/test_display_subscription.py
@@ -58,6 +58,7 @@ def test_display_only_schema():
                 "format": "summary",
                 "type": "string",
                 "uniforms": {"data": {"headers": ["one"]}},
+                "extraProperties": {"data": {"headers": ["one"]}},
             },
         },
         "title": "unknown",

--- a/tests/unit_tests/test_migration_summary.py
+++ b/tests/unit_tests/test_migration_summary.py
@@ -42,9 +42,8 @@ def test_migration_summary_schema():
                 "default": None,
                 "format": "summary",
                 "type": "string",
-                "uniforms": {
-                    "data": {"headers": ["one"]},
-                },
+                "uniforms": {"data": {"headers": ["one"]}},
+                "extraProperties": {"data": {"headers": ["one"]}},
             },
         },
         "title": "unknown",

--- a/tests/unit_tests/test_read_only_field.py
+++ b/tests/unit_tests/test_read_only_field.py
@@ -51,6 +51,7 @@ def test_read_only_field_schema(read_only_value, schema_value, schema_type, othe
                 "default": schema_value,
                 "title": "Read Only",
                 "uniforms": {"disabled": True, "value": schema_value},
+                "extraProperties": {"disabled": True, "value": schema_value},
                 "type": schema_type,
             }
         },
@@ -89,6 +90,7 @@ def test_read_only_field_list_schema(read_only_value, read_only_type, schema_val
                 "items": expected_item_type,
                 "title": "Read Only List",
                 "uniforms": {"disabled": True, "value": schema_value},
+                "extraProperties": {"disabled": True, "value": schema_value},
                 "type": "array",
             }
         },
@@ -175,6 +177,7 @@ def test_read_only_list_model():
                 "items": expected_item_type,
                 "title": "Read Only List",
                 "uniforms": {"disabled": True, "value": schema_value},
+                "extraProperties": {"disabled": True, "value": schema_value},
                 "type": "array",
             }
         },
@@ -223,6 +226,7 @@ def test_read_only_field_merge_json_schema(field_type, value, expected_format):
     read_only_schema = validated.model_json_schema()["properties"]["read_only"]
     assert read_only_schema["format"] == expected_format
     assert read_only_schema["uniforms"]["disabled"]
+    assert read_only_schema["extraProperties"]["disabled"]
 
 
 def test_read_only_unsupported_type():

--- a/tests/unit_tests/test_timestamp.py
+++ b/tests/unit_tests/test_timestamp.py
@@ -29,6 +29,14 @@ def test_timestamp_schema():
                     "showTimeSelect": True,
                     "timeFormat": None,
                 },
+                "extraProperties": {
+                    "dateFormat": None,
+                    "locale": None,
+                    "max": None,
+                    "min": None,
+                    "showTimeSelect": True,
+                    "timeFormat": None,
+                },
             },
             "t2": {
                 "format": "timestamp",
@@ -37,6 +45,14 @@ def test_timestamp_schema():
                 "title": "T2",
                 "type": "number",
                 "uniforms": {
+                    "dateFormat": "DD-MM-YYYY HH:mm",
+                    "locale": "nl-nl",
+                    "max": 1672751600,
+                    "min": 1652751600,
+                    "showTimeSelect": True,
+                    "timeFormat": "HH:mm",
+                },
+                "extraProperties": {
                     "dateFormat": "DD-MM-YYYY HH:mm",
                     "locale": "nl-nl",
                     "max": 1672751600,


### PR DESCRIPTION
Relates to https://github.com/workfloworchestrator/orchestrator-core/issues/1367

Changes the form schema to include the key `"extraProperties"` with the same content as `"uniforms"` which is now deprecated.

This will be released in pydantic-forms 2.4.0