### PR TITLE
Include default_factory values in generated form JSON schema

### DIFF
--- a/pydantic_forms/core/asynchronous.py
+++ b/pydantic_forms/core/asynchronous.py
@@ -18,7 +18,7 @@ import structlog
 from pydantic import ValidationError
 from pydantic_i18n import PydanticI18n
 
-from pydantic_forms.core.shared import FORMS
+from pydantic_forms.core.shared import FORMS, GenerateFormJsonSchema
 from pydantic_forms.core.translations import translations
 from pydantic_forms.exceptions import (
     FormException,
@@ -102,7 +102,10 @@ async def post_form(
         return generated_form
 
     # Form is not completely filled raise next form
-    raise FormNotCompleteError(generated_form.model_json_schema(), meta=getattr(generated_form, "meta__", None))
+    raise FormNotCompleteError(
+        generated_form.model_json_schema(schema_generator=GenerateFormJsonSchema),
+        meta=getattr(generated_form, "meta__", None),
+    )
 
 
 def _get_form(key: str) -> StateInputFormGeneratorAsync:

--- a/pydantic_forms/core/shared.py
+++ b/pydantic_forms/core/shared.py
@@ -11,15 +11,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from inspect import isasyncgenfunction, isgeneratorfunction
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 import structlog
 from pydantic import BaseModel, ConfigDict, PydanticUndefinedAnnotation, version
+from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
+from pydantic_core import core_schema
 
 logger = structlog.get_logger(__name__)
 
 
 PYDANTIC_VERSION = version.version_short()
+
+
+class GenerateFormJsonSchema(GenerateJsonSchema):
+    """JSON schema generator that also emits ``default`` values produced by ``default_factory``.
+
+    Pydantic intentionally leaves ``default_factory`` results out of the generated JSON schema. For
+    forms this is a problem: ``default_factory`` is the recommended way to declare mutable defaults
+    (``Field(default_factory=list)`` and friends), and frontends pre-fill fields from the schema
+    ``default``. Without it such fields render uninitialised, and dynamic array/object widgets reject
+    submission until the user performs a dummy add/remove interaction to materialise an empty value.
+
+    This generator evaluates argument-less factories and adds their result as the schema ``default``.
+    Factories that need the already-validated data (``default_factory_takes_data``) cannot be
+    evaluated at schema-generation time and are skipped, as is any factory that raises.
+    """
+
+    def default_schema(self, schema: core_schema.WithDefaultSchema) -> JsonSchemaValue:
+        json_schema = super().default_schema(schema)
+        if (
+            "default" not in json_schema
+            and "default_factory" in schema
+            and not schema.get("default_factory_takes_data", False)
+        ):
+            factory = cast(Callable[[], Any], schema["default_factory"])
+            try:
+                json_schema["default"] = self.encode_default(factory())
+            except Exception:  # noqa: B902 - never let a factory break schema generation
+                logger.debug("Could not evaluate default_factory for form schema", exc_info=True)
+        return json_schema
 
 
 class DisplayOnlyFieldType:

--- a/pydantic_forms/core/sync.py
+++ b/pydantic_forms/core/sync.py
@@ -18,7 +18,7 @@ import structlog
 from pydantic import ValidationError
 from pydantic_i18n import PydanticI18n
 
-from pydantic_forms.core.shared import FORMS
+from pydantic_forms.core.shared import FORMS, GenerateFormJsonSchema
 from pydantic_forms.core.translations import translations
 from pydantic_forms.exceptions import FormException, FormNotCompleteError, FormOverflowError, FormValidationError
 from pydantic_forms.types import InputForm, State, StateInputFormGenerator
@@ -88,7 +88,10 @@ def post_form(
             generated_form = generator.send(form_validated_data)
 
         # Form is not completely filled; raise next form
-        raise FormNotCompleteError(generated_form.model_json_schema(), meta=getattr(generated_form, "meta__", None))
+        raise FormNotCompleteError(
+            generated_form.model_json_schema(schema_generator=GenerateFormJsonSchema),
+            meta=getattr(generated_form, "meta__", None),
+        )
     except StopIteration as e:
         if user_inputs:
             raise FormOverflowError(f"Did not process all user_inputs ({len(user_inputs)} remaining)")

--- a/tests/unit_tests/test_default_factory.py
+++ b/tests/unit_tests/test_default_factory.py
@@ -1,0 +1,46 @@
+from pydantic import Field
+
+from pydantic_forms.core import FormPage, generate_form
+from pydantic_forms.types import strEnum
+
+
+def _form_schema(form_cls):
+    def input_form(state):
+        user_input = yield form_cls
+        return user_input.model_dump()
+
+    return generate_form(input_form, {}, [])
+
+
+def test_default_factory_empty_list_is_included_in_schema():
+    class Form(FormPage):
+        items: list[int] = Field(default_factory=list)
+
+    # A field using the recommended mutable-default idiom must still expose an initial value to the UI.
+    assert _form_schema(Form)["properties"]["items"]["default"] == []
+
+
+def test_default_factory_non_empty_is_included_in_schema():
+    class Form(FormPage):
+        items: list[int] = Field(default_factory=lambda: [1, 2, 3])
+
+    assert _form_schema(Form)["properties"]["items"]["default"] == [1, 2, 3]
+
+
+def test_default_factory_with_enum_values_is_serialised():
+    class Color(strEnum):
+        RED = "red"
+        GREEN = "green"
+
+    class Form(FormPage):
+        colors: list[Color] = Field(default_factory=lambda: [Color.RED, Color.GREEN])
+
+    assert _form_schema(Form)["properties"]["colors"]["default"] == ["red", "green"]
+
+
+def test_literal_default_is_unchanged():
+    class Form(FormPage):
+        items: list[int] = [1, 2]
+
+    # Literal defaults already worked; make sure the custom generator keeps them intact.
+    assert _form_schema(Form)["properties"]["items"]["default"] == [1, 2]

--- a/tests/unit_tests/test_default_factory.py
+++ b/tests/unit_tests/test_default_factory.py
@@ -44,3 +44,14 @@ def test_literal_default_is_unchanged():
 
     # Literal defaults already worked; make sure the custom generator keeps them intact.
     assert _form_schema(Form)["properties"]["items"]["default"] == [1, 2]
+
+
+def test_default_factory_that_raises_is_skipped():
+    def boom() -> list[int]:
+        raise RuntimeError("boom")
+
+    class Form(FormPage):
+        items: list[int] = Field(default_factory=boom)
+
+    # A failing factory must never break schema generation; the field simply gets no default.
+    assert "default" not in _form_schema(Form)["properties"]["items"]


### PR DESCRIPTION
## Summary

Fixes #60.

`Field(default_factory=...)` defaults were missing from the generated form JSON Schema, because Pydantic omits `default_factory` results from `model_json_schema()`. Frontends pre-fill fields (especially dynamic array/object widgets) from the schema `default`, so factory-defaulted fields rendered uninitialised and list widgets rejected submission (`expected array, received undefined`) until a dummy add/remove interaction. Since `default_factory` is Pydantic's recommended idiom for mutable defaults, the correct pattern was the one that broke pre-fill.

## Changes

- Add `GenerateFormJsonSchema(GenerateJsonSchema)` in `core/shared.py`. It overrides `default_schema` to evaluate argument-less factories and emit their result as the schema `default`.
- Use it via `model_json_schema(schema_generator=GenerateFormJsonSchema)` in both `post_form` paths (`core/sync.py`, `core/asynchronous.py`).
- Add tests covering empty `default_factory=list`, non-empty factories, enum-valued lists, and unchanged literal defaults.

## Safety / scope

- Only **adds** a `default` when one is absent and a factory is present — literal defaults are untouched (regression-tested).
- Factories that require validated data (`default_factory_takes_data`) cannot be evaluated standalone and are skipped; any factory that raises is caught and skipped, so schema generation never fails because of a factory.
- Cross-version: the `default_factory_takes_data` guard uses `.get(..., False)`, so it is a no-op on Pydantic versions that predate that core-schema key.

### Repro before/after

```python
from pydantic import Field
from pydantic_forms.core import FormPage, generate_form

class Form(FormPage):
    items: list[int] = Field(default_factory=lambda: [1, 2, 3])

def input_form(state):
    user_input = yield Form
    return user_input.model_dump()

print(generate_form(input_form, {}, [])["properties"]["items"].get("default"))
# before: None      after: [1, 2, 3]
```
