### PR TITLE
Show highlighting on nested model validation errors

### DIFF
--- a/pydantic_forms/exceptions.py
+++ b/pydantic_forms/exceptions.py
@@ -1,5 +1,6 @@
 import os
 import traceback
+from collections.abc import Mapping
 from typing import Any, Iterable, Optional, TypedDict, Union, cast
 
 import structlog
@@ -36,9 +37,24 @@ class FormOverflowError(FormException):
     """Raised when more inputs are provided than the form can process."""
 
 
+Loc = tuple[Union[int, str], ...]
+
+
+def _error_is_nested_object_validator(error: ErrorDetails) -> bool:
+    """Return True for custom errors raised for an object payload instead of a leaf field."""
+    exc = error.get("ctx", {}).get("error")
+    return (
+        bool(error["loc"])
+        and isinstance(exc, (ValueError, AssertionError))
+        and isinstance(error.get("input"), Mapping)
+    )
+
+
 # def convert_errors(validation_error: ValidationError) -> Iterable[ErrorDetails]:
 def convert_errors(
-    validation_error: ValidationError, tr: PydanticI18n, locale: str = "en_US"
+    validation_error: ValidationError,
+    tr: PydanticI18n,
+    locale: str = "en_US",
 ) -> Iterable[ErrorDetails]:
     """Convert Pydantic's error messages to our needs.
 
@@ -55,6 +71,11 @@ def convert_errors(
             # Reinstate the "__root__" location for validation errors raised by Pydantic v1's root_validator.
             # With Pydantic v2's model_validator the location is an empty string, which breaks frontend clients.
             error["loc"] = ("__root__",)
+        elif _error_is_nested_object_validator(error):
+            # Errors raised by a model_validator on a nested model point at the nested model itself, which
+            # frontend clients cannot map to an input field. Mark them as model-level errors so that clients
+            # display the custom message, like they do for the form's own "__root__" errors.
+            error["loc"] = (*error["loc"], "__root__")
         return
 
     if LOG_LEVEL_PYDANTIC_FORMS == "DEBUG":
@@ -88,9 +109,6 @@ class FormValidationError(FormException):
             f'{no_errors} validation error{"" if no_errors == 1 else "s"} for {self.validator_name}\n'
             f"{display_errors(cast(list[ErrorDict], self.errors))}"
         )
-
-
-Loc = tuple[Union[int, str], ...]
 
 
 class _ErrorDictRequired(TypedDict):

--- a/pydantic_forms/exceptions.py
+++ b/pydantic_forms/exceptions.py
@@ -44,9 +44,7 @@ def _error_is_nested_object_validator(error: ErrorDetails) -> bool:
     """Return True for custom errors raised for an object payload instead of a leaf field."""
     exc = error.get("ctx", {}).get("error")
     return (
-        bool(error["loc"])
-        and isinstance(exc, (ValueError, AssertionError))
-        and isinstance(error.get("input"), Mapping)
+        bool(error["loc"]) and isinstance(exc, (ValueError, AssertionError)) and isinstance(error.get("input"), Mapping)
     )
 
 

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import pytest
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from pydantic_forms.core import FormPage, generate_form, post_form
 from pydantic_forms.exceptions import FormNotCompleteError, FormOverflowError, FormValidationError
@@ -272,6 +272,25 @@ def test_loc_nested_model_validator(form_field_annotation, user_input, expected_
 
     assert len(e.value.errors) == 1
     assert e.value.errors[0]["loc"] == expected_loc
+    assert e.value.errors[0]["msg"] == "Yowch!"
+
+
+def test_loc_nested_model_validator_with_alias():
+    """Nested model validator errors are remapped when Pydantic reports the field alias in the location."""
+
+    def form_generator(state):
+        class Form(FormPage):
+            nested_: SubModel = Field(alias="nested")
+
+        yield Form
+
+        return {}
+
+    with pytest.raises(FormValidationError) as e:
+        post_form(form_generator, {}, [{"nested": {"enabled": False, "setting_when_enabled": 1}}])
+
+    assert len(e.value.errors) == 1
+    assert e.value.errors[0]["loc"] == ("nested", "__root__")
     assert e.value.errors[0]["msg"] == "Yowch!"
 
 

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -1,5 +1,7 @@
+from typing import Optional
+
 import pytest
-from pydantic import ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 from pydantic_forms.core import FormPage, generate_form, post_form
 from pydantic_forms.exceptions import FormNotCompleteError, FormOverflowError, FormValidationError
@@ -223,3 +225,87 @@ def test_loc():
     assert len(e.value.errors) == 1
     assert e.value.errors[0]["loc"] == ("__root__",)
     assert e.value.errors[0]["msg"] == "too high"
+
+
+class SubModel(BaseModel):
+    enabled: bool = False
+    setting_when_enabled: Optional[int] = None
+
+    @model_validator(mode="after")
+    def only_when_enabled(self) -> "SubModel":
+        if not self.enabled and self.setting_when_enabled is not None:
+            raise ValueError("Yowch!")
+        return self
+
+
+class NestedSubModel(BaseModel):
+    settings: SubModel
+
+
+@pytest.mark.parametrize(
+    "form_field_annotation, user_input, expected_loc",
+    [
+        (SubModel, {"enabled": False, "setting_when_enabled": 1}, ("nested", "__root__")),
+        (Optional[SubModel], {"enabled": False, "setting_when_enabled": 1}, ("nested", "__root__")),
+        (list[SubModel], [{"enabled": False, "setting_when_enabled": 1}], ("nested", 0, "__root__")),
+        (dict[str, SubModel], {"key": {"enabled": False, "setting_when_enabled": 1}}, ("nested", "key", "__root__")),
+        (
+            NestedSubModel,
+            {"settings": {"enabled": False, "setting_when_enabled": 1}},
+            ("nested", "settings", "__root__"),
+        ),
+    ],
+)
+def test_loc_nested_model_validator(form_field_annotation, user_input, expected_loc):
+    """Custom errors raised by a model_validator on a nested model are marked as model-level ("__root__") errors."""
+
+    def form_generator(state):
+        class Form(FormPage):
+            nested: form_field_annotation
+
+        yield Form
+
+        return {}
+
+    with pytest.raises(FormValidationError) as e:
+        post_form(form_generator, {}, [{"nested": user_input}])
+
+    assert len(e.value.errors) == 1
+    assert e.value.errors[0]["loc"] == expected_loc
+    assert e.value.errors[0]["msg"] == "Yowch!"
+
+
+def test_loc_nested_model_field_errors_are_not_remapped():
+    """Errors on leaf fields and non-validator errors on nested models keep their original location."""
+
+    def form_generator(state):
+        class Form(FormPage):
+            nested: SubModel
+            a: int
+
+            @field_validator("a")
+            @classmethod
+            def validate_a(cls, value: int) -> int:
+                if value > 5:
+                    raise ValueError("too high")
+                return value
+
+        yield Form
+
+        return {}
+
+    # A ValueError on a leaf field keeps pointing at that field
+    with pytest.raises(FormValidationError) as e:
+        post_form(form_generator, {}, [{"nested": {"enabled": True}, "a": 6}])
+
+    assert len(e.value.errors) == 1
+    assert e.value.errors[0]["loc"] == ("a",)
+    assert e.value.errors[0]["msg"] == "too high"
+
+    # A missing nested model is not a custom validator error and keeps pointing at the nested model
+    with pytest.raises(FormValidationError) as e:
+        post_form(form_generator, {}, [{"a": 1}])
+
+    assert len(e.value.errors) == 1
+    assert e.value.errors[0]["loc"] == ("nested",)
+    assert e.value.errors[0]["type"] == "missing"


### PR DESCRIPTION
## Summary

  When a `model_validator` raises on a nested model (e.g. a field of type `SubModel`),
  Pydantic reports the error location pointing at the nested model itself rather than a
  leaf field. 

Frontend clients cannot map such a location to an input field and silently
  drop the error message.

  ## Changes

  - Added `_error_is_nested_object_validator` helper in `exceptions.py` to detect this
    case: a non-empty `loc` where the error's `ctx.error` is a `ValueError`/`AssertionError`
    and the `input` is a mapping (i.e. an object payload, not a leaf value).
  - In `convert_errors`, errors matching this pattern have `__root__` appended to their
    `loc`, consistent with how top-level `model_validator` errors are already handled.
    This lets frontend clients display the custom message at the model level.
  - Added parametrized unit tests covering `SubModel`, `Optional[SubModel]`,
    `list[SubModel]`, `dict[str, SubModel]`, and doubly-nested models, plus alias and
    non-regression cases.

Closes #53