### PR TITLE
Release note categorization + renovatebot for deps, dependabot for security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,19 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
+# Dependabot handles SECURITY updates only; routine version bumps are done by
+# Renovate (see renovate.json), whose own vulnerability alerts are disabled so
+# the two bots don't open duplicate security PRs.
+#
+# `open-pull-requests-limit: 0` disables Dependabot *version* updates for the
+# ecosystem while leaving *security* updates active (those have a separate
+# internal limit and are unaffected by this setting). The `labels` below are
+# therefore applied to the security PRs, which also puts them in the right
+# section of the generated release notes (.github/release.yml).
+# https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/customizing-dependabot-security-prs
 version: 2
 updates:
-  - package-ecosystem: "uv" # Reads pyproject.toml + uv.lock
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "github-actions"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    open-pull-requests-limit: 0
+    labels:
+      - "kind/security"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,28 @@
+# Path-based auto-labeling for actions/labeler.
+# Covers the labels that can be inferred from touched files. Type labels that
+# cannot be derived from paths (kind/feature vs. kind/bug) still need to be
+# applied by the author or a reviewer — see the PR template checklist.
+kind/documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "**/*.md"
+          - "mkdocs.yml"
+
+kind/test:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "tests/**"
+
+kind/ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - ".pre-commit-config.yaml"
+          - "codecov.yml"
+
+kind/build:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "pyproject.toml"
+          - "uv.lock"

--- a/.github/labels.sh
+++ b/.github/labels.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Create or update the repository labels used by the release-notes generator
+# (.github/release.yml) and the path-based labeler (.github/labeler.yml).
+#
+# Labels are namespaced:
+#   kind/*  — the type of change (drives the changelog sections)
+#
+# `gh label create --force` is idempotent: it creates the label, or updates its
+# color/description if it already exists. Safe to run repeatedly.
+#
+# Usage:
+#   .github/labels.sh                       # acts on the current repo
+#   .github/labels.sh --repo owner/name     # extra args are forwarded to gh
+#
+# Requires the GitHub CLI (`gh auth login`).
+set -euo pipefail
+
+# name|color|description  (color is a 6-digit hex, no leading '#')
+#
+# One hue per namespace so this dedicated release-notes set reads as its own
+# family and does not clash with the existing project-filter labels (bug,
+# documentation, ...):
+#   kind/*  -> blue    (0052cc)
+#   exclusion marker -> grey (ededed)
+labels=(
+  "kind/feature|0052cc|New user-facing functionality"
+  "kind/bug|0052cc|A confirmed bug fix"
+  "kind/refactor|0052cc|Internal refactor with no behavior change"
+  "kind/chore|0052cc|Housekeeping / internal change"
+  "kind/documentation|0052cc|Documentation only"
+  "kind/test|0052cc|Tests only"
+  "kind/ci|0052cc|CI, GitHub Actions and workflow changes"
+  "kind/build|0052cc|Build system, packaging and tooling"
+  "kind/security|0052cc|Security fix or hardening"
+  "kind/dependencies|0052cc|Dependency version updates"
+  "skip-changelog|ededed|Exclude this PR from the generated release notes"
+)
+
+for entry in "${labels[@]}"; do
+  IFS='|' read -r name color description <<<"$entry"
+  echo "Syncing label: ${name}"
+  gh label create "$name" --color "$color" --description "$description" --force "$@"
+done
+
+echo "Done. ${#labels[@]} labels synced."

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- A summary of your changes -->
+
+## Related Issues
+
+Fixes # (issue number)
+
+## Type of change
+<!--
+Set a label on this PR so it is categorized in the release notes. This is
+required — the "require-release-label" check fails without one.
+Some labels (kind/documentation, kind/test, kind/ci, kind/build) are applied
+automatically from the files you changed; set the rest yourself.
+-->
+- [ ] I have set a `kind/*` label describing the change (e.g. `kind/feature`, `kind/bug`, `kind/refactor`), or `skip-changelog` if it should be left out of the notes.
+
+## Checklist
+
+- [ ] I have updated relevant documentation.
+- [ ] My code follows the style guidelines of this project as described in CLAUDE.md.

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,48 @@
+# Configuration for GitHub's auto-generated release notes.
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+#
+# Labels are namespaced (kind/*) so this dedicated release-notes set does not
+# collide with the existing project-filter labels (bug, documentation, ...).
+# Run .github/labels.sh to create/update these labels in the repo.
+#
+# Each PR is placed in the FIRST category whose labels it matches, so order
+# matters: more specific buckets (Security, Dependency Updates) come before the
+# broader ones (CI / Build).
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+  categories:
+    - title: 🚀 Features
+      labels:
+        - kind/feature
+    - title: 🐛 Bug Fixes
+      labels:
+        - kind/bug
+    - title: ♻️ Refactors & Internal Changes
+      labels:
+        - kind/refactor
+        - kind/chore
+    - title: 🧪 Tests
+      labels:
+        - kind/test
+    - title: 📚 Documentation
+      labels:
+        - kind/documentation
+    - title: 🔒 Security Updates
+      labels:
+        - kind/security
+    # Dependency Updates sits above CI / Build on purpose: a dependency PR often
+    # touches pyproject.toml / uv.lock and so also gets the path-based kind/build
+    # label. Since a PR lands in the FIRST matching category, listing
+    # dependencies first keeps those bumps in the right section.
+    - title: 📦 Dependency Updates
+      labels:
+        - kind/dependencies
+    - title: 🔧 CI / Build / Tooling
+      labels:
+        - kind/ci
+        - kind/build
+    - title: 🔀 Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,68 @@
+name: PR labels
+
+# Applies path-based labels AND enforces that every PR carries a release-notes
+# label. These MUST live in one workflow: the enforcement job `needs` the
+# labeler job so it always evaluates the labels *after* they have been applied.
+# Running them as separate workflows races — the check reads a label snapshot
+# from before the labeler runs, and labels added by GITHUB_TOKEN don't trigger
+# a re-run, so the check gets stuck failing.
+#
+# NOTE: to actually block merging, add the `require-release-label` job as a
+# required status check in the branch protection rules for 'main'.
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-24.04
+    steps:
+      # `sync-labels: true` means the labeler both adds and REMOVES labels — but
+      # ONLY the ones it can derive from changed paths (see .github/labeler.yml:
+      # kind/documentation, kind/test, kind/ci, kind/build).
+      #
+      # It deliberately does NOT touch the type labels that require developer
+      # judgement (kind/feature, kind/bug, kind/refactor, kind/security, ...) or
+      # skip-changelog. Those cannot be inferred from file paths — they are the
+      # author's/reviewer's call — so they are set by hand and left untouched
+      # here. The require-release-label job below enforces that at least one
+      # such label ends up on the PR.
+      - name: "🏷️ Apply path-based labels"
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true
+
+  require-release-label:
+    # Run after the labeler so path-based labels are already applied, and even
+    # if the labeler was skipped or failed.
+    needs: label
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Fail if no release-notes label is set
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          # Read the *live* labels, not the (stale) event payload snapshot.
+          LABELS=$(gh pr view "${PR}" --repo "${REPO}" --json labels --jq '[.labels[].name]')
+          echo "Labels on this PR: ${LABELS}"
+          if echo "${LABELS}" | jq -e 'any(.[]; startswith("kind/") or . == "skip-changelog")' >/dev/null; then
+            echo "Found a release-notes label — OK."
+          else
+            echo "::error::This PR needs a 'kind/*' label (e.g. kind/feature, kind/bug), or 'skip-changelog' to exclude it, so it is handled correctly in the release notes."
+            exit 1
+          fi

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": ["kind/dependencies"],
+  "packageRules": [
+    {
+      "matchManagers": ["uv"]
+    },
+    {
+      "description": "Label GitHub Actions bumps so they land in the CI/Build release-notes section",
+      "matchManagers": ["github-actions"],
+      "labels": ["kind/ci"]
+    },
+    {
+      "matchPackageNames": ["python"],
+      "rangeStrategy": "widen",
+      "enabled": false
+    }
+  ],
+  "minimumReleaseAge": "3 days",
+  "vulnerabilityAlerts": {
+    "enabled": false
+  },
+  "osvVulnerabilityAlerts": false,
+  "internalChecksFilter": "strict",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 3am on Tuesday"]
+  },
+  "schedule": [
+    "* 1-5 * * *"
+  ],
+  "timezone": "Europe/Amsterdam",
+  "updateNotScheduled": false
+}


### PR DESCRIPTION

* Add release note categorization based on labels, similar as added to the orchestrator-core last week
* Change dependabot to only handle security bumps from now on
* Start using renovatebot for weekly dependency updates

Reason to add the split is to be consistent with orchestrator-core, and so we can have separate labels/changelog categories for security updates.