### PR TITLE
Set uv minimum release age in accordance with other libraries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,11 @@ dev = [
 requires = ["uv_build>=0.10,<0.13"]
 build-backend = "uv_build"
 
+[tool.uv]
+# Cooldown: don't resolve versions published in the last 3 days (supply-chain protection).
+# Keep in sync with minimumReleaseAge in renovate.json.
+exclude-newer = "3 days"
+
 [tool.uv.build-backend]
 module-name = "pydantic_forms"
 module-root = ""

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.10, <3.15"
 
+[options]
+exclude-newer = "2026-08-09T10:42:36.843111Z"
+exclude-newer-span = "P3D"
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.5"


### PR DESCRIPTION
## Summary

Set `uv` minimum release age to 3 days for dependency cooldown.

## Related Issues

n/a

## Type of change
<!--
Set a label on this PR so it is categorized in the release notes. This is
required — the "require-release-label" check fails without one.
Some labels (kind/documentation, kind/test, kind/ci, kind/build) are applied
automatically from the files you changed; set the rest yourself.
-->
- [x] I have set a `kind/*` label describing the change (e.g. `kind/feature`, `kind/bug`, `kind/refactor`), or `skip-changelog` if it should be left out of the notes.

## Checklist

- [ ] I have updated relevant documentation.
- [ ] My code follows the style guidelines of this project as described in CLAUDE.md.
