### PR TITLE
Add kind/breaking label for breaking changes in release notes

### DIFF
--- a/.github/labels.sh
+++ b/.github/labels.sh
@@ -23,7 +23,13 @@ set -euo pipefail
 # documentation, ...):
 #   kind/*  -> blue    (0052cc)
 #   exclusion marker -> grey (ededed)
+#
+# kind/breaking is the one deliberate exception: red (b60205), because it is the
+# label a reviewer most needs to spot on a PR list. Note the repo also has an
+# older, unnamespaced "breaking change" label in the same red; that one is left
+# alone here — kind/breaking is the one that drives the release notes.
 labels=(
+  "kind/breaking|b60205|Breaking change — requires action from users when upgrading"
   "kind/feature|0052cc|New user-facing functionality"
   "kind/bug|0052cc|A confirmed bug fix"
   "kind/refactor|0052cc|Internal refactor with no behavior change"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,8 +12,13 @@ Set a label on this PR so it is categorized in the release notes. This is
 required — the "require-release-label" check fails without one.
 Some labels (kind/documentation, kind/test, kind/ci, kind/build) are applied
 automatically from the files you changed; set the rest yourself.
+
+A PR lands in only the FIRST matching release-notes section, and Breaking
+Changes comes first — so a breaking feature is listed there rather than under
+Features. That is intended: it is the section people read when upgrading.
 -->
 - [ ] I have set a `kind/*` label describing the change (e.g. `kind/feature`, `kind/bug`, `kind/refactor`), or `skip-changelog` if it should be left out of the notes.
+- [ ] If this is a breaking change, I have set `kind/breaking`. Breaking changes belong in a **major** release, and the summary above should describe what users must do to upgrade — it ends up in the release notes.
 
 ## Checklist
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -13,6 +13,17 @@ changelog:
     labels:
       - skip-changelog
   categories:
+    # Breaking Changes is deliberately first. A breaking change is often also a
+    # feature or a bug fix, and since a PR lands in only the FIRST matching
+    # category it is listed here instead of there — that is the section readers
+    # of a major release need to see, and it keeps it from being buried.
+    #
+    # There is no way to make a category depend on the version being released:
+    # .github/release.yml is static config. The section is self-gating instead —
+    # it only appears when a PR in the release range carries kind/breaking.
+    - title: ⚠️ Breaking Changes
+      labels:
+        - kind/breaking
     - title: 🚀 Features
       labels:
         - kind/feature


### PR DESCRIPTION
## Summary

Breaking changes are currently invisible in the generated release notes — they land in 🚀 Features or ♻️ Refactors like any other PR. This adds a dedicated `kind/breaking` label and a ⚠️ Breaking Changes section.

- **`.github/release.yml`** — the section is listed **first**. Since a PR lands in only the first matching category, a PR that is both a feature and a breaking change is listed as breaking rather than under Features. That is intentional: it is the section people read when upgrading.
- **`.github/labels.sh`** — `kind/breaking` in red (`b60205`) instead of the `kind/*` blue, so it stands out on the PR list.
- **`.github/pull_request_template.md`** — a checklist item noting that a breaking change belongs in a **major** release and that the PR summary should describe the upgrade path, since it ends up in the release notes.

### Notes

GitHub's release-notes config is static and cannot key off the version being cut, so "only for major releases" is not directly expressible. The section is self-gating instead: it only renders when a PR in the release range actually carries the label.

`.github/labeler.yml` is deliberately untouched — breaking-ness cannot be derived from file paths, so it stays a human call like `kind/feature` vs `kind/bug`. The `require-release-label` check already accepts any `kind/*` prefix, so no workflow change was needed.

The label has already been created in this repo via `.github/labels.sh`. The same change is going out to `orchestrator-core`, `nwa-stdlib`, `oauth2-lib` and `pydantic-forms` so the four repos stay consistent.

## Type of change

- [x] I have set a `kind/*` label describing the change — `kind/ci`, applied automatically from the changed paths.
- [ ] If this is a breaking change, I have set `kind/breaking`. — n/a

## Checklist

- [x] I have updated relevant documentation. — the PR template and inline config comments.
- [x] My code follows the style guidelines of this project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)