### PR TITLE
Pin GitHub Actions to commit digests via Renovate

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -26,3 +26,4 @@ kind/build:
       - any-glob-to-any-file:
           - "pyproject.toml"
           - "uv.lock"
+          - "renovate.json"

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ],
   "labels": ["kind/dependencies"],
   "packageRules": [


### PR DESCRIPTION
## Summary

Two small config changes.

**1. Pin GitHub Actions to commit digests.** Adds the [`helpers:pinGitHubActionDigests`](https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests) preset to `renovate.json`. Renovate will then rewrite every external `uses:` reference to `action@<full-sha> # vX.Y.Z` and keep both the digest and the trailing version comment in sync from then on.

Git tags are mutable. Anyone able to move `actions/checkout@v6` owns our next CI run — silently, with no diff, retroactively affecting workflows written months ago. Pinning by digest means a moved tag changes nothing for us until a Renovate PR lands, which turns a silent swap into a reviewable one. GitHub's [secure-use guidance](https://docs.github.com/en/actions/reference/security/secure-use) puts it plainly: *"Pinning an action to a full-length commit SHA is currently the only way to use an action as an immutable release."*

**2. Label `renovate.json` in the labeler.** It matched none of the globs in `.github/labeler.yml`, so a PR touching only that file got no path-based label and tripped `require-release-label` with nothing the author could reasonably guess. Added to `kind/build` — the label covers "build system, packaging and tooling", and Renovate config is dependency tooling even though part of what it bumps is Actions.

### What to expect

Renovate will open a one-time pin PR converting all external actions. After that, digest bumps ride along with the normal version PRs.

- **`pypa/gh-action-pypi-publish@release/v1` gets pinned too.** That branch ref stops floating, so we rely on Renovate digest bumps for publishing fixes rather than picking them up implicitly. This is the one behavioral change; happy to exclude it with a `pinDigests: false` rule if reviewers prefer the moving ref.
- **Local reusable workflow references are unaffected.**

The existing `minimumReleaseAge: 3 days` still applies and Actions updates are not automerged, so every digest change gets human review. That review step is what makes the scheme worth anything — blind-automerging digest updates would just rebuild tag-following with extra steps.

## Related Issues

N/A — proactive supply-chain hardening.

## Type of change

- [x] I have set a `kind/*` label describing the change — `kind/ci`, applied automatically since this touches `.github/**`.
- [x] If this is a breaking change, I have set `kind/breaking`. — Not breaking; config-only, no runtime or API impact.

## Checklist

- [x] I have updated relevant documentation. — No user-facing docs cover Renovate config.
- [x] My code follows the style guidelines of this project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
